### PR TITLE
Fix JSON syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,5 +23,5 @@
         "url": "http://github.com/philikon/MockHttpRequest"
     }],
     "dependencies": [],
-    "homepage": "http://github.com/philikon/MockHttpRequest",
+    "homepage": "http://github.com/philikon/MockHttpRequest"
 }


### PR DESCRIPTION
package.json was invalid JSON due to extra dangling comma after the last property of the root object.
This caused problems with some build tools that try to read the package.json.